### PR TITLE
Remove git:// and update to https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ configuration won't work for this, because it only acts on filenames.
 Install the plugin using `pip`:
 
 ```shell
-pip install git+git://github.com/edgars-supe/beets-importreplace.git
+pip install git+https://github.com/edgars-supe/beets-importreplace.git
 ```
 
 Then, [configure](#configuration) the plugin in your


### PR DESCRIPTION
git:// protocol has been phased out on GitHub. Installing with `pip install git+git://github.com/edgars-supe/beets-importreplace.git` is currently broken. 

```
$ pip install git+git://github.com/edgars-supe/beets-importreplace.git
Defaulting to user installation because normal site-packages is not writeable
Collecting git+git://github.com/edgars-supe/beets-importreplace.git
  Cloning git://github.com/edgars-supe/beets-importreplace.git to /tmp/pip-req-build-8s5_z1c9
  Running command git clone --filter=blob:none --quiet git://github.com/edgars-supe/beets-importreplace.git /tmp/pip-req-build-8s5_z1c9
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  error: subprocess-exited-with-error

  × git clone --filter=blob:none --quiet git://github.com/edgars-supe/beets-importreplace.git /tmp/pip-req-build-8s5_z1c9 did not run successfully.
  │ exit code: 128
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× git clone --filter=blob:none --quiet git://github.com/edgars-supe/beets-importreplace.git /tmp/pip-req-build-8s5_z1c9 did not run successfully.
│ exit code: 128
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

The updated command works:
```
$ pip install git+https://github.com/edgars-supe/beets-importreplace.git
Defaulting to user installation because normal site-packages is not writeable
Collecting git+https://github.com/edgars-supe/beets-importreplace.git
  Cloning https://github.com/edgars-supe/beets-importreplace.git to /tmp/pip-req-build-_krnl51c
  Running command git clone --filter=blob:none --quiet https://github.com/edgars-supe/beets-importreplace.git /tmp/pip-req-build-_krnl51c
  Resolved https://github.com/edgars-supe/beets-importreplace.git to commit 0f8d95abd4da4a8ce589832e3cf769ae9db4340e
  Preparing metadata (setup.py) ... done
Collecting beets>=1.4.7
  Downloading beets-1.6.0.tar.gz (1.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 16.7 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Requirement already satisfied: confuse>=1.0.0 in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (1.7.0)
Requirement already satisfied: jellyfish in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (0.8.9)
Requirement already satisfied: mediafile>=0.2.0 in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (0.9.0)
Requirement already satisfied: munkres>=1.0.0 in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (1.1.4)
Requirement already satisfied: musicbrainzngs>=0.4 in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (0.7.1)
Requirement already satisfied: pyyaml in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (5.4.1)
Requirement already satisfied: unidecode in /usr/lib/python3/dist-packages (from beets>=1.4.7->beets-importreplace==0.2) (1.3.3)
Requirement already satisfied: mutagen>=1.45 in /usr/lib/python3/dist-packages (from mediafile>=0.2.0->beets>=1.4.7->beets-importreplace==0.2) (1.45.1)
Requirement already satisfied: six>=1.9 in /usr/lib/python3/dist-packages (from mediafile>=0.2.0->beets>=1.4.7->beets-importreplace==0.2) (1.16.0)
Building wheels for collected packages: beets-importreplace, beets
  Building wheel for beets-importreplace (setup.py) ... done
  Created wheel for beets-importreplace: filename=beets_importreplace-0.2-py3-none-any.whl size=3948 sha256=83e74fb821292b6d5b2327d4b3d27d5a4838bbe79bd5909b4e2bfe994d1eca4e
  Stored in directory: /tmp/pip-ephem-wheel-cache-1r6wu49_/wheels/e3/3d/ce/bd39372ad85fa69a5023384a1c81483bd5c6b3b0c6f378606b
  Building wheel for beets (setup.py) ... done
  Created wheel for beets: filename=beets-1.6.0-py3-none-any.whl size=499712 sha256=80acacf9e539da5512a97808c0aed3e86ad93d3755f4d1980f7321285d9b81ec
  Stored in directory: /home/arsaboo/.cache/pip/wheels/93/89/2d/645f35f3a8028288591e30728c8d3cbffce250b0f40a9c84de
Successfully built beets-importreplace beets
Installing collected packages: beets, beets-importreplace
  WARNING: The script beet is installed in '/home/arsaboo/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
Successfully installed beets-1.6.0 beets-importreplace-0.2
```