### PR TITLE
support replacing in list-type fields

### DIFF
--- a/beetsplug/importreplace.py
+++ b/beetsplug/importreplace.py
@@ -1,6 +1,11 @@
 import re
 from functools import reduce
-from re import Pattern
+try:
+    from re import Pattern
+except ImportError:
+    # re.Pattern was introduced in Python 3.7
+    from sre_parse import Pattern
+from typing import Union
 
 from beets.autotag import TrackInfo, AlbumInfo
 from beets.plugins import BeetsPlugin
@@ -68,9 +73,9 @@ class ImportReplace(BeetsPlugin):
         for track in info.tracks:
             self._trackinfo_received(track)
 
-    def _replace_field(self, text: str|list, replacements: [(Pattern, str)]) -> str|list:
+    def _replace_field(self, text: Union[str, list], replacements: [(Pattern, str)]) -> Union[str, list]:
         if isinstance(text, list):
-            return list(map(lambda item: reduce(self._replace, replacements, item), text))
+            return list(map(lambda item: self._replace_field(item, replacements), text))
         else:
             return reduce(self._replace, replacements, text)
 

--- a/beetsplug/importreplace.py
+++ b/beetsplug/importreplace.py
@@ -68,9 +68,11 @@ class ImportReplace(BeetsPlugin):
         for track in info.tracks:
             self._trackinfo_received(track)
 
-    def _replace_field(self, text: str, replacements: [(Pattern, str)]) -> str:
-
-        return reduce(self._replace, replacements, text)
+    def _replace_field(self, text: str|list, replacements: [(Pattern, str)]) -> str|list:
+        if isinstance(text, list):
+            return list(map(lambda item: reduce(self._replace, replacements, item), text))
+        else:
+            return reduce(self._replace, replacements, text)
 
     def _replace(self, text: str, replacement: (Pattern, str)) -> str:
         return replacement[0].sub(repl=replacement[1], string=text)

--- a/tests/test_importreplace.py
+++ b/tests/test_importreplace.py
@@ -15,15 +15,23 @@ class ImportReplaceTest(unittest.TestCase):
         beets.config['importreplace'] = {'replacements': []}
 
     def _create_track_info(self, title: str = None, artist: str = None,
-                           artist_sort: str = None, artist_credit: str = None):
+                           artist_sort: str = None, artist_credit: str = None,
+                           artists: [str]= None, artists_sort: [str] = None,
+                           artists_credit: [str] = None):
         return TrackInfo(title=title, artist=artist, artist_sort=artist_sort,
-                         artist_credit=artist_credit)
+                         artist_credit=artist_credit, artists=artists,
+                         artists_sort=artists_sort,
+                         artists_credit=artists_credit)
 
     def _create_album_info(self, tracks: [TrackInfo] = None, album: str = None,
                            artist: str = None, artist_sort: str = None,
-                           artist_credit: str = None):
+                           artist_credit: str = None, artists: [str] = None,
+                           artists_sort: [str] = None,
+                           artists_credit: [str] = None):
         return AlbumInfo(tracks=tracks or [], album=album, artist=artist,
-                         artist_sort=artist_sort, artist_credit=artist_credit)
+                         artist_sort=artist_sort, artist_credit=artist_credit,
+                         artists=artists, artists_sort=artists_sort,
+                         artists_credit=artists_credit)
 
     def _add_replacement(self, item_fields: [str] = None,
                          album_fields: [str] = None,
@@ -46,31 +54,40 @@ class ImportReplaceTest(unittest.TestCase):
                               replace={'The': 'A'})
         tracks = [self._create_track_info(title='The Piece', artist='The Dude')]
         album_info = self._create_album_info(tracks=tracks, album='The Album',
-                                             artist='The Dude')
+                                             artist='The Dude',
+                                             artists=['The Dude', 'This Artist'])
         subject = ImportReplace()
         subject._albuminfo_received(album_info)
         self.assertEqual(album_info.album, 'A Album')
         self.assertEqual(album_info.artist, 'The Dude')
         self.assertEqual(album_info.tracks[0].title, 'A Piece')
         self.assertEqual(album_info.tracks[0].artist, 'The Dude')
+        self.assertEqual(album_info.artists[0], 'The Dude')
+        self.assertEqual(album_info.artists[1], 'This Artist')
 
     def test_replaces_only_config_fields_multiple(self):
         """Check if plugin replaces text in only the specified fields when
         multiple replacements given."""
         self._add_replacement(item_fields=['title'], album_fields=['album'],
                               replace={'The': 'A'})
-        self._add_replacement(item_fields=['artist'], album_fields=['artist'],
+        self._add_replacement(item_fields=['artist'],
+                              album_fields=['artist', 'artists'],
                               replace={'This': 'That'})
         tracks = [self._create_track_info(title='The Piece', artist='The This')]
         album_info = self._create_album_info(tracks=tracks,
                                              album='The Album',
-                                             artist='The This')
+                                             artist='The This',
+                                             artists=['The This', 'This Artist'],
+                                             artists_credit=['The This'])
         subject = ImportReplace()
         subject._albuminfo_received(album_info)
         self.assertEqual(album_info.album, 'A Album')
         self.assertEqual(album_info.artist, 'The That')
         self.assertEqual(album_info.tracks[0].title, 'A Piece')
         self.assertEqual(album_info.tracks[0].artist, 'The That')
+        self.assertEqual(album_info.artists[0], 'The That')
+        self.assertEqual(album_info.artists[1], 'That Artist')
+        self.assertEqual(album_info.artists_credit[0], 'The This')
 
     def test_handles_empty_fields(self):
         """Verify that plugin works when field marked for replacement
@@ -129,10 +146,14 @@ class ImportReplaceTest(unittest.TestCase):
         tracks = [self._create_track_info(title='The Piece', artist='The This')]
         album_info = self._create_album_info(tracks=tracks,
                                              album='The Album',
-                                             artist='The This')
+                                             artist='The This',
+                                             artists=['The Dude', 'This Artist'],
+                                             )
         subject = ImportReplace()
         subject._albuminfo_received(album_info)
         self.assertEqual(album_info.album, 'The Album')
         self.assertEqual(album_info.artist, 'The That')
         self.assertEqual(album_info.tracks[0].title, 'A Piece')
         self.assertEqual(album_info.tracks[0].artist, 'The This')
+        self.assertEqual(album_info.artists[0], 'The Dude')
+        self.assertEqual(album_info.artists[1], 'This Artist')

--- a/tests/test_importreplace.py
+++ b/tests/test_importreplace.py
@@ -5,6 +5,7 @@ from beets.autotag.hooks import AlbumInfo
 from beets.autotag.hooks import TrackInfo
 from beetsplug.importreplace import ImportReplace
 
+# multi-valued tags was added in beets v2.0.0 (#4743)
 
 class ImportReplaceTest(unittest.TestCase):
 
@@ -17,21 +18,40 @@ class ImportReplaceTest(unittest.TestCase):
     def _create_track_info(self, title: str = None, artist: str = None,
                            artist_sort: str = None, artist_credit: str = None,
                            artists: [str]= None, artists_sort: [str] = None,
-                           artists_credit: [str] = None):
-        return TrackInfo(title=title, artist=artist, artist_sort=artist_sort,
-                         artist_credit=artist_credit, artists=artists,
-                         artists_sort=artists_sort,
-                         artists_credit=artists_credit)
+                           artists_credit: [str] = None, track_id: str = None):
+        try:
+            return TrackInfo(title=title, track_id=track_id, artist=artist,
+                             artist_sort=artist_sort,
+                             artist_credit=artist_credit, artists=artists,
+                             artists_sort=artists_sort,
+                             artists_credit=artists_credit)
+        except TypeError:
+            # beets <1.5.0 uses positional arguments
+            return TrackInfo(title, track_id, artist=artist,
+                             artist_sort=artist_sort,
+                             artist_credit=artist_credit)
 
     def _create_album_info(self, tracks: [TrackInfo] = None, album: str = None,
                            artist: str = None, artist_sort: str = None,
                            artist_credit: str = None, artists: [str] = None,
                            artists_sort: [str] = None,
-                           artists_credit: [str] = None):
-        return AlbumInfo(tracks=tracks or [], album=album, artist=artist,
-                         artist_sort=artist_sort, artist_credit=artist_credit,
-                         artists=artists, artists_sort=artists_sort,
-                         artists_credit=artists_credit)
+                           artists_credit: [str] = None, album_id: str = None,
+                           artist_id: str = None):
+        album_info = None
+        try:
+            album_info = AlbumInfo(album=album, album_id=album_id, artist=artist,
+                                   artist_id=artist_id, tracks=tracks or [],
+                                   artist_sort=artist_sort,
+                                   artist_credit=artist_credit,
+                                   artists=artists, artists_sort=artists_sort,
+                                   artists_credit=artists_credit)
+        except TypeError as e:
+            # beets <1.5.0 uses positional arguments
+            album_info = AlbumInfo(album, album_id, artist, artist_id,
+                                   tracks=tracks or [], artist_sort=artist_sort,
+                                   artist_credit=artist_credit)
+        finally:
+            return album_info
 
     def _add_replacement(self, item_fields: [str] = None,
                          album_fields: [str] = None,


### PR DESCRIPTION
This PR addresses https://github.com/edgars-supe/beets-importreplace/issues/7 by adding support for replacing in the list-type fields returned by the Musicbrainz database.

If the field being modified is a list, the replacements are applied to each item in the list.  This has the potential to (further) increase the processing time when importing based on the number of replacement rules, although pre-compiling and reusing the patterns should help.